### PR TITLE
Add meson cross definition file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then build thermobench:
 
 	make aarch64
 
-The resulting binary `build-aarch64/src/demos-sched` can be copied to
+The resulting binary `build-aarch64/src/thermobench` can be copied to
 the target ARM system.
 
 ## Usage

--- a/aarch64.txt
+++ b/aarch64.txt
@@ -1,0 +1,23 @@
+# -*-conf-*-
+
+# This is a Meson cross build definition file
+
+# This file assumes that path to the arm compiler toolchain is added
+# to the environment(PATH) variable, so that Meson can find
+# the armcc, armlink and armar while building.
+[binaries]
+c = 'aarch64-linux-gnu-gcc'
+cpp = 'aarch64-linux-gnu-g++'
+ar = 'aarch64-linux-gnu-ar'
+strip = 'aarch64-linux-gnu-strip'
+
+[properties]
+# The '--cpu' option with the appropriate target type should be mentioned
+# to cross compile c/c++ code with armcc,.
+cpp_link_args = ['-static']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'aarch64'
+cpu = 'armv8-a'
+endian = 'little'


### PR DESCRIPTION
Copied the file `aarch64.txt` verbatim from `CTU-IIG/demos-sched` which
fixed the `aarch64` make target.